### PR TITLE
FoundryVTT v9 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
       "name": "Daniel Solano Gómez"
     }
   ],
-  "minimumCoreVersion": "0.7.5",
+  "minimumCoreVersion": "0.8.6",
   "compatibleCoreVersion": "0.8.9",
   "esmodules": "{{sources}}",
   "socket": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "safety-tools",
 	"title": "Safety Tools",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "Safety Tools for Foundry VTT",
 	"devDir": "/home/dan/.local/share/FoundryVTT/Data/modules/",
 	"main": "src/index.ts",


### PR DESCRIPTION
- fixes https://github.com/SpectralCiphers/safety-tools/issues/4
- removed 0.7 legacy code because it did not work with 0.7.10 anyways
- replaced bringToTop call, becaue it threw an error on console when window was not on screen
- call render with focus option to make sure card window is maximized and on top