### PR TITLE
Make SafetyToolsLayer extend InteractionLayer for Foundry VTT v10

### DIFF
--- a/src/SafetyToolsLayer.ts
+++ b/src/SafetyToolsLayer.ts
@@ -1,4 +1,4 @@
-export class SafetyToolsLayer extends CanvasLayer {
+export class SafetyToolsLayer extends InteractionLayer {
   public constructor() {
     super();
     console.log('Safety Tools | Loaded into canvas');


### PR DESCRIPTION
This seems to fix Foundry VTT v10 compatibility. I tested it locally with v10.288 and it seems to work.

I don't really know how to build this module into something foundry eats, so to test it, I instead directly modified SafetyToolsLayer.js in my local foundry modules directory. My change seems to be 1:1 from the SafetyToolsLayer.ts, but I haven't tested a "proper" build.